### PR TITLE
Add configurable S3 backup

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@ This Terraform module sets up a robust Jenkins infrastructure in AWS, including 
 - **CloudWatch Integration:**
   - Logs are forwarded to CloudWatch with customizable retention periods.
 
+- **Backup:**
+  - Optional automated backups of Jenkins data to an S3 bucket on a configurable schedule.
+
 - **Customization:**
   - All major settings, such as instance sizes, security rules, and Jenkins configurations, can be overridden.
 
@@ -110,6 +113,9 @@ This Terraform module sets up a robust Jenkins infrastructure in AWS, including 
 | `jenkins_slave_agent_port`  | Port configuration for Jenkins slave agents.           | `string`              | `"8090"`                      | No       |
 | `cpu`                       | CPU to allocate for Jenkins in Docker.                 | `number`              | `500`                         | No       |
 | `memory`                    | Memory to allocate for Jenkins in Docker.              | `number`              | `1024`                        | No       |
+| `backup_enabled`           | Enable automated backups to S3.                         | `bool`                | `false`                       | No       |
+| `backup_bucket_name`       | Name of the S3 bucket used for backups.                 | `string`              | `""`                          | No       |
+| `backup_schedule`          | Cron expression for the backup job.                     | `string`              | `"0 3 * * *"`                 | No       |
 | `security_groups`           | Security group configurations for Jenkins.             | `list(object({...}))` | See default                   | No       |
 
 
@@ -140,6 +146,9 @@ module "jenkins" {
   efs_performance_mode  = "generalPurpose"
   efs_throughput_mode   = "bursting"
   retention_in_days     = 14
+  backup_enabled        = true
+  backup_bucket_name    = "jenkins-backups"
+  backup_schedule       = "0 3 * * *"
 
   # Add additional security groups if needed
   additional_security_groups = [

--- a/main.tf
+++ b/main.tf
@@ -45,7 +45,8 @@ data "aws_iam_policy" "jenkins" {
   for_each = toset([
     "arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceEventsRole",
     "arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceRole",
-    "arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceforEC2Role"
+    "arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceforEC2Role",
+    "arn:aws:iam::aws:policy/AmazonS3FullAccess"
   ])
   arn = each.key
 }
@@ -266,7 +267,12 @@ resource "aws_launch_template" "launch_template" {
   name_prefix   = "lc_Jenkins"
   instance_type = var.instance_type
   image_id =  length(var.ami_id) > 0 ? var.ami_id : local.ami_id
-  user_data     = base64encode("${templatefile("${path.module}/script/instance_setup.sh", { cluster_name = "${aws_ecs_cluster.jenkins.name}"})}")
+  user_data     = base64encode("${templatefile("${path.module}/script/instance_setup.sh", {
+    cluster_name    = aws_ecs_cluster.jenkins.name,
+    backup_enabled  = var.backup_enabled,
+    backup_bucket_name = var.backup_bucket_name,
+    backup_schedule = var.backup_schedule
+  })}")
   network_interfaces {
     associate_public_ip_address = true
     security_groups             = [aws_security_group.this["jenkins-ingress"].id, aws_security_group.this["jenkins-efs"].id, aws_security_group.this["jenkins-egress"].id, aws_security_group.this["jenkins-agent"].id]
@@ -285,6 +291,20 @@ resource "aws_launch_template" "launch_template" {
 resource "aws_cloudwatch_log_group" "Jenkins" {
   name              = var.cloudwatch_name
   retention_in_days = var.retention_in_days
+}
+
+resource "aws_s3_bucket" "backup" {
+  count  = var.backup_enabled ? 1 : 0
+  bucket = var.backup_bucket_name
+}
+
+resource "aws_s3_bucket_public_access_block" "backup" {
+  count  = var.backup_enabled ? 1 : 0
+  bucket = aws_s3_bucket.backup[0].id
+  block_public_acls   = true
+  block_public_policy = true
+  ignore_public_acls  = true
+  restrict_public_buckets = true
 }
 
 

--- a/script/instance_setup.sh
+++ b/script/instance_setup.sh
@@ -7,6 +7,8 @@ set -exu
 # Assign ec2 instance to proper clusters
 echo "ECS_CLUSTER=${cluster_name}" >> /etc/ecs/ecs.config
 
-
-
+# Configure backup cron job if enabled
+if [ "${backup_enabled}" = "true" ]; then
+  echo "${backup_schedule} root aws s3 sync /var/jenkins_home s3://${backup_bucket_name} --delete" > /etc/cron.d/jenkins_backup
+fi
 

--- a/variable.tf
+++ b/variable.tf
@@ -249,3 +249,20 @@ variable "additional_security_groups" {
   }))
   default = []
 }
+variable "backup_enabled" {
+  description = "Whether to enable Jenkins backup to S3"
+  type        = bool
+  default     = false
+}
+
+variable "backup_bucket_name" {
+  description = "S3 bucket name for Jenkins backups"
+  type        = string
+  default     = ""
+}
+
+variable "backup_schedule" {
+  description = "Cron expression for backup job"
+  type        = string
+  default     = "0 3 * * *"
+}


### PR DESCRIPTION
## Summary
- add optional backup variables
- attach S3 policy and pass backup settings to the launch template
- create S3 bucket for backups
- setup cron-based sync of EFS to S3 on EC2 instances
- document backup feature and usage
