### PR TITLE
Performance improvement and ability to add jenkins environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,32 +126,34 @@ Managing Jenkins on AWS can be complex — this module simplifies it with:
 
 # Input
 
-| Name                        | Description                                            | Type                  | Default                       | Required |
-|-----------------------------|--------------------------------------------------------|-----------------------|-------------------------------|----------|
-| `jenkins_url`               | The URL for the Jenkins instance.                      | `string`              | `"http://localhost:8080/"`    | No       |
-| `region`                    | AWS region for the deployment.                         | `string`              | `"us-east-1"`                 | No       |
-| `vpc_id`                    | The ID of the VPC to deploy resources into.            | `string`              | `""`                          | Yes      |
-| `cloudwatch_name`           | CloudWatch log group name for Jenkins logs.            | `string`              | `"/jenkins/logs"`             | No       |
-| `efs_creation_token`        | Name of the EFS file system.                           | `string`              | `"jenkins-efs"`               | No       |
-| `efs_performance_mode`      | EFS performance mode.                                  | `string`              | `"generalPurpose"`            | No       |
-| `efs_throughput_mode`       | EFS throughput mode.                                   | `string`              | `"bursting"`                  | No       |
-| `retention_in_days`         | Number of days to retain CloudWatch logs.              | `number`              | `7`                           | No       |
-| `additional_security_groups`| Additional security group configurations.              | `list(object({...}))` | `[]`                          | No       |
-| `ami_id`                    | Specify your own ECS-optimized AMI for the module.     | `string`              | `""`                          | No       |
-| `enable_update_plugins`     | Enables automatic plugin updates in Jenkins.           | `bool`                | `false`                       | No       |
-| `min_instance_size`         | Minimum number of EC2 instances.                       | `number`              | `1`                           | No       |
-| `desired_service_count`     | Desired number of ECS services.                        | `number`              | `1`                           | No       |
-| `max_instance_size`         | Maximum number of EC2 instances.                       | `number`              | `1`                           | No       |
-| `instance_type`             | Type of EC2 instance.                                  | `string`              | `"t2.medium"`                 | No       |
-| `cloudwatch_environment`    | CloudWatch environment.                                | `string`              | `"Sandbox"`                   | No       |
-| `jenkins_image`             | Jenkins Docker image for the master.                   | `string`              | `"jenkins/jenkins:lts"`       | No       |
-| `jenkins_slave_agent_port`  | Port configuration for Jenkins slave agents.           | `string`              | `"8090"`                      | No       |
-| `cpu`                       | CPU to allocate for Jenkins in Docker.                 | `number`              | `500`                         | No       |
-| `memory`                    | Memory to allocate for Jenkins in Docker.              | `number`              | `1024`                        | No       |
-| `security_groups`           | Security group configurations for Jenkins.             | `list(object({...}))` | See default                   | No       |
-| `backup_schedule`           | Cron expression to set backup schedule.                | `string`              | `cron(0 6 ? * MON-FRI *)`     | No       |
-| `enable_backup`             | Enable back to S3 from EFS.                            | `bool`                | `false`                       | No       |
-| `force_delete_s3`           | Force delete data from S3 before destroying bucket.    | `bool`                | `true`                        | No       |
+| Name                            | Description                                            | Type                  | Default                       | Required |
+|---------------------------------|--------------------------------------------------------|-----------------------|-------------------------------|----------|
+| `region`                        | AWS region for the deployment.                         | `string`              | `"us-east-1"`                 | No       |
+| `vpc_id`                        | The ID of the VPC to deploy resources into.            | `string`              | `""`                          | Yes      |
+| `cloudwatch_name`               | CloudWatch log group name for Jenkins logs.            | `string`              | `"/jenkins/logs"`             | No       |
+| `efs_creation_token`            | Name of the EFS file system.                           | `string`              | `"jenkins-efs"`               | No       |
+| `efs_performance_mode`          | EFS performance mode.                                  | `string`              | `"generalPurpose"`            | No       |
+| `efs_throughput_mode`           | EFS throughput mode.                                   | `string`              | `"bursting"`                  | No       |
+| `retention_in_days`             | Number of days to retain CloudWatch logs.              | `number`              | `7`                           | No       |
+| `additional_security_groups`    | Additional security group configurations.              | `list(object({...}))` | `[]`                          | No       |
+| `ami_id`                        | Specify your own ECS-optimized AMI for the module.     | `string`              | `""`                          | No       |
+| `enable_update_plugins`         | Enables automatic plugin updates in Jenkins.           | `bool`                | `false`                       | No       |
+| `min_instance_size`             | Minimum number of EC2 instances.                       | `number`              | `1`                           | No       |
+| `desired_service_count`         | Desired number of ECS services.                        | `number`              | `1`                           | No       |
+| `max_instance_size`             | Maximum number of EC2 instances.                       | `number`              | `1`                           | No       |
+| `instance_type`                 | Type of EC2 instance.                                  | `string`              | `"t2.medium"`                 | No       |
+| `cloudwatch_environment`        | CloudWatch environment.                                | `string`              | `"Sandbox"`                   | No       |
+| `jenkins_image`                 | Jenkins Docker image for the master.                   | `string`              | `"jenkins/jenkins:lts"`       | No       |
+| `cpu`                           | CPU to allocate for Jenkins in Docker.                 | `number`              | `500`                         | No       |
+| `memory`                        | Memory to allocate for Jenkins in Docker.              | `number`              | `1024`                        | No       |
+| `security_groups`               | Security group configurations for Jenkins.             | `list(object({...}))` | See default                   | No       |
+| `backup_schedule`               | Cron expression to set backup schedule.                | `string`              | `cron(0 6 ? * MON-FRI *)`     | No       |
+| `enable_backup`                 | Enable back to S3 from EFS.                            | `bool`                | `false`                       | No       |
+| `force_delete_s3`               | Force delete data from S3 before destroying bucket.    | `bool`                | `true`                        | No       |
+| `jenkins_environment_variables` | Map of environment variables to inject into the Jenkins| `map(string)`         | See Example Section           | No       |
+
+
+
 
 
 
@@ -176,7 +178,6 @@ module "jenkins" {
   source = "umairshaikh45/jenkins/aws"
 
   # Override defaults if needed
-  jenkins_url           = "http://jenkins.example.com:8080/"
   region                = "us-east-1"
   vpc_id                = "vpc-12345678"
   cloudwatch_name       = "/jenkins/logs"
@@ -184,6 +185,14 @@ module "jenkins" {
   efs_performance_mode  = "generalPurpose"
   efs_throughput_mode   = "bursting"
   retention_in_days     = 14
+
+  # Jenkins container environment variables (Default)
+  jenkins_environment_variables = {
+    JAVA_OPTS                = "-Djenkins.install.runSetupWizard=false"
+    JENKINS_SLAVE_AGENT_PORT = "8090"
+    TRY_UPGRADE_IF_NO_MARKER = "true"
+    JENKINS_URL              = "http://localhost:8080/"
+  }
 
   # Add additional security groups if needed
   additional_security_groups = [
@@ -226,4 +235,5 @@ Apache 2 Licensed. See [LICENSE](https://github.com/umairshaikh45/terraform-aws-
 
 ## Jenkins on ECS Architecture Diagram
 
-![Jenkins ECS Architecture](./images/Diagram.png)
+![Jenkins ECS Architecture](https://raw.githubusercontent.com/umairshaikh45/terraform-aws-jenkins/Master/images/Diagram.png)
+

--- a/main.tf
+++ b/main.tf
@@ -90,13 +90,13 @@ resource "null_resource" "update_plugins" {
   provisioner "local-exec" {
     command = "bash ${path.module}/script/plugins_update.sh"
     environment = {
-      JENKINS_URL = var.jenkins_url
+      JENKINS_URL = var.jenkins_environment_variables["JENKINS_URL"]
     }
   }
 
   triggers = {
     sha256_digest = data.docker_registry_image.jenkins.sha256_digest
-    jenkins_url   = var.jenkins_url
+    jenkins_url   = var.jenkins_environment_variables["JENKINS_URL"]
   }
 }
 
@@ -152,14 +152,13 @@ resource "aws_efs_mount_target" "jenkins-efs-mount" {
 resource "aws_ecs_task_definition" "Job" {
   family = "jenkins"
   container_definitions = templatefile("${path.module}/templates/jenkins.json.tpl", {
-    image                    = "jenkins/jenkins@${data.docker_registry_image.jenkins.sha256_digest}",
-    aws_log_group            = aws_cloudwatch_log_group.Jenkins.id,
-    aws_region               = var.region,
-    aws_prefix               = aws_cloudwatch_log_group.Jenkins.name
-    jenkins_slave_agent_port = var.jenkins_slave_agent_port
-    cpu                      = var.cpu
-    memory                   = var.memory
-    jenkins_url              = var.jenkins_url
+    image                         = "jenkins/jenkins@${data.docker_registry_image.jenkins.sha256_digest}",
+    aws_log_group                 = aws_cloudwatch_log_group.Jenkins.id,
+    aws_region                    = var.region,
+    aws_prefix                    = aws_cloudwatch_log_group.Jenkins.name
+    jenkins_environment_variables = var.jenkins_environment_variables,
+    cpu                           = var.cpu
+    memory                        = var.memory
   })
   task_role_arn = aws_iam_role.host_role_jenkins.arn
   volume {
@@ -180,7 +179,9 @@ resource "aws_ecs_service" "jenkins" {
   task_definition      = aws_ecs_task_definition.Job.arn
   desired_count        = 1
   force_new_deployment = true
-  depends_on           = [aws_autoscaling_group.asg_jenkins]
+   lifecycle {
+    create_before_destroy = true
+  }
 }
 
 #-----Define cluster-----

--- a/templates/jenkins.json.tpl
+++ b/templates/jenkins.json.tpl
@@ -6,24 +6,14 @@
     "memory": ${memory},
     "essential": true,
     "user":"jenkins",
-     "environment": [
-        {
-          "name": "JAVA_OPTS",
-          "value": "-Djenkins.install.runSetupWizard=false"
-        },
-        {
-          "name": "JENKINS_SLAVE_AGENT_PORT",
-          "value": "${jenkins_slave_agent_port}"
-        },
-        {
-          "name": "TRY_UPGRADE_IF_NO_MARKER",
-          "value": "true"
-        },
-         {
-          "name": "JENKINS_URL",
-          "value": "${jenkins_url}"
-        }
-      ],
+    "environment": [
+%{ for key, value in jenkins_environment_variables ~}
+  {
+    "name": "${key}",
+    "value": "${value}"
+  }%{ if key != keys(jenkins_environment_variables)[length(jenkins_environment_variables) - 1] },%{ endif }
+%{ endfor ~}
+],
     "volumesFrom": [],
     "portMappings": [
       {
@@ -33,8 +23,8 @@
       },
       {
         "protocol": "tcp",
-        "containerPort": ${jenkins_slave_agent_port},
-        "hostPort": ${jenkins_slave_agent_port}
+        "containerPort": ${jenkins_environment_variables["JENKINS_SLAVE_AGENT_PORT"]},
+        "hostPort": ${jenkins_environment_variables["JENKINS_SLAVE_AGENT_PORT"]}
       }
     ],
       "mountPoints": [

--- a/variable.tf
+++ b/variable.tf
@@ -71,11 +71,6 @@ variable "retention_in_days" {
   type        = number
   default     = 7
 }
-variable "jenkins_slave_agent_port" {
-  description = "Environment port configuration for slave"
-  type        = string
-  default     = "8090"
-}
 variable "cpu" {
   description = "Amount of cpu to be use in docker for jenkins"
   type        = number
@@ -85,11 +80,6 @@ variable "memory" {
   description = "Amount of memory to be use in docker for jenkins"
   type        = number
   default     = 1024
-}
-variable "jenkins_url" {
-  description = "Jenkins url configuration"
-  type        = string
-  default     = "http://localhost:8080/"
 }
 variable "backup_schedule" {
   description = "Backup schedule from efs to s3"
@@ -105,6 +95,16 @@ variable "force_delete_s3" {
   description = "Delete backup from s3"
   type        = bool
   default     = true
+}
+variable "jenkins_environment_variables" {
+  description = "Map of Jenkins environment variables to inject into ECS container."
+  type        = map(string)
+  default = {
+    JAVA_OPTS                = "-Djenkins.install.runSetupWizard=false"
+    JENKINS_SLAVE_AGENT_PORT = "8090"
+    TRY_UPGRADE_IF_NO_MARKER = "true"
+    JENKINS_URL              = "http://localhost:8080/"
+  }
 }
 variable "security_groups" {
   description = "List of security group configurations"


### PR DESCRIPTION
This PR introduces performance improvements and adds support for injecting custom Jenkins environment variables via a single configurable map.

### 🔧 Enhancements:
- Added `jenkins_environment_variables` as a map variable with sensible defaults (e.g., JENKINS_URL, JAVA_OPTS)
- Replaced hardcoded ECS container environment blocks with dynamic mapping for better flexibility and reuse
- Cleaned up template file structure for easier maintenance and rendering
- Removed unnecessary `depends_on` from ECS service to improve destroy reliability

These changes make the module easier to customize and improve deployment lifecycle performance when managing Auto Scaling Groups and ECS services.
